### PR TITLE
Execute `which pip` as root user

### DIFF
--- a/lib/itamae/plugin/recipe/supervisor/service.rb
+++ b/lib/itamae/plugin/recipe/supervisor/service.rb
@@ -7,7 +7,7 @@ when /rhel-6\.(.*?)/
     mode '755'
   end
 when /rhel-7\.(.*?)/
-  pip_path = run_command('which pip').stdout
+  pip_path = run_command('which pip', user: 'root').stdout
   template '/etc/systemd/system/supervisord.service' do
     user 'root'
     owner 'root'


### PR DESCRIPTION
This PR changes the user who executes `pip` to root.

---

I got an error while installing supervisor.

```
ERROR :           stdout | unix:///tmp/supervisor.sock no such file
ERROR :           Command `sudo -H -u root -- /bin/sh -c cd\ \~root\ \;\ supervisorctl\ restart\ shibauthorizer\ shibresponder` failed. (exit status: 7)
ERROR :         execute[supervisorctl restart shibauthorizer shibresponder] Failed.
```

I checked `/etc/systemd/system/supervisord.service` and found something wrong.
```
[Service]
ExecStart=/home/User/.local/bin/supervisord -n -c /etc/supervisord.conf
ExecStop=/home/User/.local/bin/supervisorctl $OPTIONS shutdown
ExecReload=/home/User/.local/bin/supervisorctl $OPTIONS reload
```

The template of the above is here:
https://github.com/maedadev/itamae-plugin-recipe-supervisor/blob/63f750d8e4cf103f9fbf3c79efd1f0cf4de6bd6a/lib/itamae/plugin/recipe/supervisor/templates/etc/systemd/system/supervisord.service.erb#L6-L9

`@dir_path` is defined here:
https://github.com/maedadev/itamae-plugin-recipe-supervisor/blob/63f750d8e4cf103f9fbf3c79efd1f0cf4de6bd6a/lib/itamae/plugin/recipe/supervisor/service.rb#L10-L16

I don't know why, but `pip` is installed at `~/.local/bin` in my environment.

```
$ which pip
~/.local/bin/pip
```

However `supervisor` is installed as root here:
https://github.com/maedadev/itamae-plugin-recipe-supervisor/blob/63f750d8e4cf103f9fbf3c79efd1f0cf4de6bd6a/lib/itamae/plugin/recipe/supervisor/install.rb#L1-L5

and `pip` for root is installed in a different path from that of a general user.

```
$ sudo which pip
/usr/local/bin/pip
```

Running `pip` as root user solved the problem.